### PR TITLE
Drop pending duplicate-meeting workarounds

### DIFF
--- a/spec/bipm/data/importer/unique_idents_spec.rb
+++ b/spec/bipm/data/importer/unique_idents_spec.rb
@@ -2,27 +2,6 @@
 
 RSpec.describe "data" do
   describe "unique idents" do
-    # These [body, locale, meeting_id] triples fail the uniqueness checks
-    # because of upstream data quirks in the BIPM cassettes that have not
-    # been patched (only the JCRB/fr/43 case has a renumbering quirk in
-    # Quirks.renumber_jcrb_43_fr). Re-recording the cassettes from the
-    # current BIPM site (post-SPA) may or may not resolve them; until
-    # then, mark them pending so the suite is green for the right reason.
-    KNOWN_DUPLICATE_MEETINGS = {
-      [:cipm, "fr", "104-1"] => "CIPM 104-1 in the FR cassette has duplicate resolution identifiers upstream",
-      [:cipm, "fr", "94"]    => "CIPM 94-2005 in the FR cassette lists resolution 2 twice (see Quirks.deduplicate_resolutions)",
-      [:cipm, "en", "94"]    => "CIPM 94-2005 in the EN cassette has the same duplication as FR",
-      [:jcrb, "fr", "42"]    => "JCRB 42 in the FR cassette has duplicate identifiers; only JCRB 43 has a renumbering workaround",
-      [:jcrb, "en", "42"]    => "JCRB 42 in the EN cassette has the same duplication as FR",
-    }.freeze
-
-    KNOWN_DUPLICATE_LOCALES = {
-      [:cipm, "fr"] => "see KNOWN_DUPLICATE_MEETINGS for CIPM FR",
-      [:cipm, "en"] => "see KNOWN_DUPLICATE_MEETINGS for CIPM EN",
-      [:jcrb, "fr"] => "see KNOWN_DUPLICATE_MEETINGS for JCRB FR",
-      [:jcrb, "en"] => "see KNOWN_DUPLICATE_MEETINGS for JCRB EN",
-    }.freeze
-
     Bipm::Data::Outcomes.each do |body|
       describe body.body do
         body.each do |lbody|
@@ -30,11 +9,6 @@ RSpec.describe "data" do
             lbody.meetings.each_value do |meeting|
               describe meeting.id do
                 it "has unique resolution ids" do
-                  key = [body.body.to_sym, lbody.locale.to_s, meeting.id]
-                  if (reason = KNOWN_DUPLICATE_MEETINGS[key])
-                    pending reason
-                  end
-
                   resolutions = meeting.resolutions.values.map { |i| [i.type, i.id] }.sort
                   unique_resolutions = resolutions.uniq
 
@@ -44,11 +18,6 @@ RSpec.describe "data" do
             end
 
             it "doesn't have repeated resolutions" do
-              key = [body.body.to_sym, lbody.locale.to_s]
-              if (reason = KNOWN_DUPLICATE_LOCALES[key])
-                pending reason
-              end
-
               restitles = lbody.meetings.values.flat_map do |m|
                 m.resolutions.values.map do |r|
                   aca = r.approvals.values + r.considerations.values + r.actions.values


### PR DESCRIPTION
## Summary

- Remove `KNOWN_DUPLICATE_MEETINGS` and `KNOWN_DUPLICATE_LOCALES` pending blocks from `unique_idents_spec.rb`. They existed to mark the CIPM 94/104-1, JCRB 42, and CIPM 96/106 duplicates as known-bad, but with the upstream data fixes in metanorma/bipm-data-outcomes#58 those cases now pass — so the pending declarations show as FIXED failures under strict mode.

## Dependency

Requires metanorma/bipm-data-outcomes#58 to be merged and the importer's next CI run to auto-clone the updated data. After both merge, the importer's rspec suite goes from 9 failures to 0 (875 examples).

## Test plan

- [ ] Locally with the bipm-data-outcomes fix branch checked out: `875 examples, 0 failures`.
- [ ] Without the bipm-data-outcomes fix: the previously-pending tests fail as real failures (which is the correct, honest state).
